### PR TITLE
Add bearer auth for SSE server

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ To expose MCP tools through a web interface:
 
 ```yaml
 # web_server_config.yaml
+host:
+  name: "chuk-mcp-runtime"
+  log_level: "INFO"
+
+server:
+  type: "sse"
+  auth: "bearer" # this line is needed to enable bearer auth
+
 proxy:
   enabled: true
   namespace: "proxy"

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ host:
 
 server:
   type: "sse"
+  auth: "bearer" # this line is needed to enable bearer auth
 
 # optional overrides
 sse:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
   "mcp>=1.6.0",
   "pydantic>=2.10.6",
   "pyyaml>=6.0.2",
+  "pyjwt>=2.10.1",
+  "cryptography>=44.0.3"
 ]
 
 [project.optional-dependencies]

--- a/src/chuk_mcp_runtime/common/verify_credentials.py
+++ b/src/chuk_mcp_runtime/common/verify_credentials.py
@@ -1,0 +1,36 @@
+import os
+import jwt
+from jwt import PyJWTError
+from jwt.exceptions import ExpiredSignatureError
+
+from typing import Optional
+from starlette.exceptions import HTTPException
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "my-test-key")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+
+
+async def validate_token(token: str) -> dict:
+    try:
+        # Decode and validate token
+        payload = jwt.decode(
+            token,
+            JWT_SECRET_KEY,
+            algorithms=[JWT_ALGORITHM],
+            # options={"require": ["exp"]},  # Require expiration
+        )
+        payload["token"] = token
+        return payload  # Contains the claims (e.g., user info)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except PyJWTError:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )


### PR DESCRIPTION
Tested from MCP inspector. Auth working for /sse and /messages/ endpoints.

Can be enabled from config.yaml
```yaml
server:
  type: "sse"
  auth: "bearer" # this line is needed to enable bearer auth
```
Default JWT_SECRET_KEY is my-test-key