### PR TITLE
Security: Upgrade MCP dependency to v1.23.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "uvicorn>=0.34.0",
   "chuk-artifacts>=0.8.1",
   "chuk-sessions>=0.5.1",
-  "mcp>=1.12.0",
+  "mcp>=1.23.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Upgraded the MCP Python SDK to mcp>=1.23.0 to address a security vulnerability related to missing default DNS rebinding protection in earlier versions.

Older versions allowed potential DNS rebinding attacks when running unauthenticated, HTTP-based MCP servers on localhost without explicit transport security configuration. This issue has been resolved in v1.23.0.

No functional changes expected. This update aligns with MCP security best practices.